### PR TITLE
Expand associatedMedia to support images, audio

### DIFF
--- a/lexicons/bio/lexicons/temp/occurrence.json
+++ b/lexicons/bio/lexicons/temp/occurrence.json
@@ -32,7 +32,7 @@
             "description": "Array of media references documenting the observation (Darwin Core dwc:associatedMedia).",
             "items": {
               "type": "union",
-              "refs": ["#imageMedia", "#audioMedia", "#videoMedia"]
+              "refs": ["#imageMedia", "#audioMedia"]
             },
             "maxLength": 10
           },
@@ -93,28 +93,6 @@
           "type": "string",
           "description": "Alt text description of the audio for accessibility.",
           "maxLength": 1000
-        }
-      }
-    },
-    "videoMedia": {
-      "type": "object",
-      "description": "A reference to an uploaded video blob.",
-      "required": ["video"],
-      "properties": {
-        "video": {
-          "type": "blob",
-          "accept": ["video/mp4", "video/webm", "video/quicktime"],
-          "maxSize": 50000000,
-          "description": "The video blob reference."
-        },
-        "alt": {
-          "type": "string",
-          "description": "Alt text description of the video for accessibility.",
-          "maxLength": 1000
-        },
-        "aspectRatio": {
-          "type": "ref",
-          "ref": "#aspectRatio"
         }
       }
     },

--- a/site/src/components/ArchitectureDiagram.tsx
+++ b/site/src/components/ArchitectureDiagram.tsx
@@ -21,7 +21,7 @@ export default function ArchitectureDiagram() {
       <Link to="/identification"><strong>identification</strong></Link>{"\n"}
       {"  \u2514\u2500 "}<strong>#taxon</strong>{"              \u2500\u2500references\u2500\u2500\u25B6  "}<Link to="/occurrence"><strong>occurrence</strong></Link>{"\n"}
       {"                                                \u2514\u2500 "}<strong>#location</strong>{"\n"}
-      {"                                                \u2514\u2500 "}<strong>#imageMedia</strong>{" "}<strong>#audioMedia</strong>{" "}<strong>#videoMedia</strong>
+      {"                                                \u2514\u2500 "}<strong>#imageMedia</strong>{" "}<strong>#audioMedia</strong>
     </Paper>
   );
 }

--- a/site/src/data/lexicons.ts
+++ b/site/src/data/lexicons.ts
@@ -160,7 +160,6 @@ export const ATPROTO_FIELDS = new Set([
   "subject",
   "image",
   "audio",
-  "video",
   "alt",
   "aspectRatio",
   "width",


### PR DESCRIPTION
## Summary

- Replace the single `#associatedMedia` def with a union of three typed media defs: `#imageMedia`, `#audioMedia`, `#videoMedia`
- Each def has appropriate MIME types and size limits (images 10MB, audio 25MB)
- `#aspectRatio` shared by image and video defs (not audio)
- Update site to handle union type rendering, examples, and architecture diagram

## Test plan

- [ ] `npm run build` in `site/` passes
- [ ] Occurrence lexicon page renders three new def accordions (`#imageMedia`, `#audioMedia`, `#videoMedia`)
- [ ] `associatedMedia` field shows union type label `(#imageMedia | #audioMedia | #videoMedia)[]`
- [ ] Full example JSON shows both image and audio items with `$type` discriminators
- [ ] Architecture diagram shows updated media def names