### PR TITLE
Trim identification lexicon to MVP

### DIFF
--- a/lexicons/bio/lexicons/temp/identification.json
+++ b/lexicons/bio/lexicons/temp/identification.json
@@ -27,6 +27,11 @@
             "default": "species",
             "maxLength": 32
           },
+          "kingdom": {
+            "type": "string",
+            "description": "Taxonomic kingdom for disambiguating homonyms (Darwin Core dwc:kingdom).",
+            "maxLength": 64
+          },
           "vernacularName": {
             "type": "string",
             "description": "Common name for the taxon in the identifier's language (Darwin Core dwc:vernacularName).",

--- a/lexicons/bio/lexicons/temp/identification.json
+++ b/lexicons/bio/lexicons/temp/identification.json
@@ -17,12 +17,7 @@
           },
           "scientificName": {
             "type": "string",
-            "description": "The full scientific name (Darwin Core dwc:scientificName).",
-            "maxLength": 256
-          },
-          "scientificNameAuthorship": {
-            "type": "string",
-            "description": "The authorship information for the scientificName (Darwin Core dwc:scientificNameAuthorship).",
+            "description": "The full scientific name, with authorship and date information if known (Darwin Core dwc:scientificName).",
             "maxLength": 256
           },
           "taxonRank": {
@@ -36,36 +31,6 @@
             "type": "string",
             "description": "Common name for the taxon in the identifier's language (Darwin Core dwc:vernacularName).",
             "maxLength": 256
-          },
-          "kingdom": {
-            "type": "string",
-            "description": "Taxonomic kingdom (Darwin Core dwc:kingdom).",
-            "maxLength": 64
-          },
-          "phylum": {
-            "type": "string",
-            "description": "Taxonomic phylum (Darwin Core dwc:phylum).",
-            "maxLength": 64
-          },
-          "class": {
-            "type": "string",
-            "description": "Taxonomic class (Darwin Core dwc:class).",
-            "maxLength": 64
-          },
-          "order": {
-            "type": "string",
-            "description": "Taxonomic order (Darwin Core dwc:order).",
-            "maxLength": 64
-          },
-          "family": {
-            "type": "string",
-            "description": "Taxonomic family (Darwin Core dwc:family).",
-            "maxLength": 64
-          },
-          "genus": {
-            "type": "string",
-            "description": "Taxonomic genus (Darwin Core dwc:genus).",
-            "maxLength": 64
           },
           "identificationRemarks": {
             "type": "string",

--- a/lexicons/bio/lexicons/temp/identification.json
+++ b/lexicons/bio/lexicons/temp/identification.json
@@ -32,11 +32,6 @@
             "description": "Taxonomic kingdom for disambiguating homonyms (Darwin Core dwc:kingdom).",
             "maxLength": 64
           },
-          "vernacularName": {
-            "type": "string",
-            "description": "Common name for the taxon in the identifier's language (Darwin Core dwc:vernacularName).",
-            "maxLength": 256
-          },
           "identificationRemarks": {
             "type": "string",
             "description": "Explanation or reasoning for this identification (Darwin Core dwc:identificationRemarks).",

--- a/site/src/data/lexicons.ts
+++ b/site/src/data/lexicons.ts
@@ -153,16 +153,9 @@ export const MODELS: ModelConfig[] = [
           uri: "at://did:plc:abc123.../bio.lexicons.temp.occurrence/3k...",
           cid: "bafyrei...",
         },
-        scientificName: "Aphelocoma californica",
-        scientificNameAuthorship: "(Vigors, 1839)",
+        scientificName: "Aphelocoma californica (Vigors, 1839)",
         taxonRank: "species",
         vernacularName: "California Scrub-Jay",
-        kingdom: "Animalia",
-        phylum: "Chordata",
-        class: "Aves",
-        order: "Passeriformes",
-        family: "Corvidae",
-        genus: "Aphelocoma",
         identificationRemarks:
           "Blue head and wings, white eyebrow, gray-brown back — classic California Scrub-Jay",
       },
@@ -194,7 +187,6 @@ export const GBIF_REQUIRED = new Set([
 
 export const GBIF_RECOMMENDED = new Set([
   "taxonRank",
-  "kingdom",
   "decimalLatitude",
   "decimalLongitude",
 ]);

--- a/site/src/data/lexicons.ts
+++ b/site/src/data/lexicons.ts
@@ -187,6 +187,7 @@ export const GBIF_REQUIRED = new Set([
 
 export const GBIF_RECOMMENDED = new Set([
   "taxonRank",
+  "kingdom",
   "decimalLatitude",
   "decimalLongitude",
 ]);

--- a/site/src/data/lexicons.ts
+++ b/site/src/data/lexicons.ts
@@ -141,7 +141,6 @@ export const MODELS: ModelConfig[] = [
         },
         scientificName: "Aphelocoma californica",
         taxonRank: "species",
-        vernacularName: "California Scrub-Jay",
       },
       null,
       2
@@ -155,7 +154,6 @@ export const MODELS: ModelConfig[] = [
         },
         scientificName: "Aphelocoma californica (Vigors, 1839)",
         taxonRank: "species",
-        vernacularName: "California Scrub-Jay",
         identificationRemarks:
           "Blue head and wings, white eyebrow, gray-brown back — classic California Scrub-Jay",
       },


### PR DESCRIPTION
## Summary
- Remove `scientificNameAuthorship` — per DwC spec, `scientificName` should include authorship when known
- Remove taxonomy hierarchy fields (`phylum`, `class`, `order`, `family`, `genus`) — derivable from a taxonomy backbone service, not needed in user-submitted records
- Keep `kingdom` for homonym disambiguation (e.g. *Morus* exists in both Plantae and Animalia)
- Remove `vernacularName` — derivable from GBIF taxonomy backbone, not needed in user-submitted records
- Update `scientificName` description to match DwC definition
- Update site example data to reflect simplified schema

Remaining fields: `subject`, `scientificName`, `taxonRank`, `kingdom`, `identificationRemarks` (5 fields, down from 11).

## Test plan
- [x] Site builds successfully
- [ ] Review lexicon JSON validity