### PR TITLE
Rename identification subject to occurrence

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,7 +7,7 @@ The lexicons follow a **star schema** with the occurrence record at the center:
 ```
 ┌─────────────────┐    ┌─────────────┐    ┌─────────────┐
 │  identification  │──▶│  occurrence  │──▶│    media     │
-│  subject: ref    │    │  (central)  │    │  image      │
+│  occurrence: ref │    │  (central)  │    │  image      │
 │  scientificName  │    │  eventDate  │    │  alt        │
 │  taxonRank       │    │  lat/lng    │    │  license    │
 │  ...             │    │  media refs │    │  ...        │

--- a/lexicons/bio/lexicons/temp/identification.json
+++ b/lexicons/bio/lexicons/temp/identification.json
@@ -8,12 +8,12 @@
       "key": "tid",
       "record": {
         "type": "object",
-        "required": ["subject", "scientificName"],
+        "required": ["occurrence", "scientificName"],
         "properties": {
-          "subject": {
+          "occurrence": {
             "type": "ref",
             "ref": "com.atproto.repo.strongRef",
-            "description": "A strong reference (CID + URI) to the observation being identified."
+            "description": "A strong reference (CID + URI) to the occurrence being identified."
           },
           "scientificName": {
             "type": "string",

--- a/site/src/data/lexicons.ts
+++ b/site/src/data/lexicons.ts
@@ -135,7 +135,7 @@ export const MODELS: ModelConfig[] = [
     shortExample: JSON.stringify(
       {
         $type: "bio.lexicons.temp.identification",
-        subject: {
+        occurrence: {
           uri: "at://did:plc:abc123.../bio.lexicons.temp.occurrence/3k...",
           cid: "bafyrei...",
         },
@@ -148,7 +148,7 @@ export const MODELS: ModelConfig[] = [
     fullExample: JSON.stringify(
       {
         $type: "bio.lexicons.temp.identification",
-        subject: {
+        occurrence: {
           uri: "at://did:plc:abc123.../bio.lexicons.temp.occurrence/3k...",
           cid: "bafyrei...",
         },
@@ -168,7 +168,7 @@ export const FIELD_TO_DWC: Record<string, string> = {};
 
 /** Fields that are AT Protocol infrastructure (no DwC mapping) */
 export const ATPROTO_FIELDS = new Set([
-  "subject",
+  "occurrence",
   "image",
   "alt",
   "aspectRatio",


### PR DESCRIPTION
## Summary
- Renames the `subject` field in the identification lexicon to `occurrence`, aligning with [DwC-DP identification schema](https://github.com/gbif/dwc-dp/blob/0.1/dwc-dp/table-schemas/identification.json) naming conventions
- Updates examples in site data and architecture diagram to match

## Test plan
- [x] Verify site builds successfully
- [x] Confirm identification lexicon renders correctly on the site