### PR TITLE
Trim README and drop ASCII diagram from architecture doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,27 +2,15 @@
 
 AT Protocol lexicons for decentralized biodiversity observation data, aligned with [Darwin Core](https://dwc.tdwg.org/) and [GBIF](https://www.gbif.org/) standards.
 
-**[lexicons.bio](https://lexicons.bio)** — Full documentation, field references, and Darwin Core alignment tables.
-
-These lexicons define the record types used by [Observ.ing](https://observ.ing), a decentralized biodiversity observation platform built on the [AT Protocol](https://atproto.com/).
-
-## Lexicons
-
-| NSID | Description |
-|------|-------------|
-| `bio.lexicons.temp.occurrence` | A biodiversity observation — organism at a place and time |
-| `bio.lexicons.temp.identification` | A taxonomic determination for an observation |
+See **[lexicons.bio](https://lexicons.bio)** for the full reference.
 
 ## Development
 
 ```bash
 cd site
 npm install
-npm run dev      # Start dev server
-npm run build    # Build for production
+npm run dev
 ```
-
-The site is built with Vite + React + MUI and lives in `site/`. Lexicon JSON files live in `lexicons/` and Darwin Core terms are sourced from `schemas/dwc/term_versions.csv`.
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,19 +2,7 @@
 
 ## Record Relationships
 
-The lexicons follow a **star schema** with the occurrence record at the center:
-
-```
-┌─────────────────┐    ┌─────────────┐    ┌─────────────┐
-│  identification  │──▶│  occurrence  │──▶│    media     │
-│  occurrence: ref │    │  (central)  │    │  image      │
-│  scientificName  │    │  eventDate  │    │  alt        │
-│  taxonRank       │    │  lat/lng    │    │  license    │
-│  ...             │    │  media refs │    │  ...        │
-└─────────────────┘    └─────────────┘    └─────────────┘
-```
-
-Records reference each other via `com.atproto.repo.strongRef` — a pair of URI + CID that creates an immutable, content-addressed link. Identifications reference occurrences, and occurrences reference media.
+The lexicons follow a star schema with the occurrence record at the center. Records reference each other via `com.atproto.repo.strongRef` — a pair of URI + CID that creates an immutable, content-addressed link. Identifications reference occurrences, and occurrences reference media.
 
 ## Key Design Decisions
 


### PR DESCRIPTION
## Summary
- README now points at the website instead of duplicating lexicon list, project description, and dev details
- Removed the ASCII star-schema diagram from `docs/architecture.md`; surrounding prose kept

## Test plan
- [ ] Render README on GitHub and confirm links/format
- [ ] Skim `docs/architecture.md` to confirm Record Relationships section still reads cleanly