### PR TITLE
Make site layout responsive at narrow widths

### DIFF
--- a/site/src/components/DwcAlignmentTable.tsx
+++ b/site/src/components/DwcAlignmentTable.tsx
@@ -44,69 +44,66 @@ export default function DwcAlignmentTable({ classes, dwcTerms, lexProps }: Props
   }
 
   return (
-    <Box
-      component="table"
-      sx={{ width: "100%", borderCollapse: "collapse", fontSize: "12.5px" }}
-    >
-      <tbody>
-        {rows.map((r, i) => (
+    <Box sx={{ fontSize: "12.5px", borderTop: `1px solid ${palette.rule}` }}>
+      {rows.map((r) => (
+        <Box
+          key={r.term}
+          sx={{
+            borderBottom: `1px solid ${palette.ruleSoft}`,
+            display: "flex",
+            alignItems: "baseline",
+            gap: { xs: "8px", sm: "10px" },
+            py: "6px",
+          }}
+        >
           <Box
-            key={r.term}
-            component="tr"
             sx={{
-              borderTop: i === 0 ? `1px solid ${palette.rule}` : "none",
-              borderBottom: `1px solid ${palette.ruleSoft}`,
+              fontFamily: fonts.mono,
+              fontSize: "12px",
+              color: r.mapped ? palette.ink : palette.warn,
+              flex: 1,
+              minWidth: 0,
+              overflowWrap: "anywhere",
             }}
           >
-            <Box
-              component="td"
-              sx={{
-                fontFamily: fonts.mono,
-                fontSize: "12px",
-                p: "6px 10px 6px 0",
-                color: r.mapped ? palette.ink : palette.warn,
-              }}
-            >
-              {r.iri ? (
-                <Box
-                  component="a"
-                  href={r.iri}
-                  target="_blank"
-                  rel="noopener"
-                  sx={{ color: "inherit", textDecoration: "none" }}
-                >
-                  {r.term}
-                </Box>
-              ) : (
-                r.term
-              )}
-            </Box>
-            <Box
-              component="td"
-              sx={{
-                fontFamily: fonts.mono,
-                fontSize: "11px",
-                color: palette.inkFaint,
-                p: "6px 10px",
-              }}
-            >
-              {r.cls}
-            </Box>
-            <Box
-              component="td"
-              sx={{
-                fontFamily: fonts.mono,
-                fontSize: "11px",
-                p: "6px 0 6px 10px",
-                color: r.mapped ? palette.moss : palette.warn,
-                textAlign: "right",
-              }}
-            >
-              {r.mapped ? "mapped" : "—"}
-            </Box>
+            {r.iri ? (
+              <Box
+                component="a"
+                href={r.iri}
+                target="_blank"
+                rel="noopener"
+                sx={{ color: "inherit", textDecoration: "none" }}
+              >
+                {r.term}
+              </Box>
+            ) : (
+              r.term
+            )}
           </Box>
-        ))}
-      </tbody>
+          <Box
+            sx={{
+              fontFamily: fonts.mono,
+              fontSize: "11px",
+              color: palette.inkFaint,
+              display: { xs: "none", sm: "block" },
+              flex: "0 0 auto",
+            }}
+          >
+            {r.cls}
+          </Box>
+          <Box
+            sx={{
+              fontFamily: fonts.mono,
+              fontSize: "11px",
+              color: r.mapped ? palette.moss : palette.warn,
+              textAlign: "right",
+              flex: "0 0 auto",
+            }}
+          >
+            {r.mapped ? "mapped" : "—"}
+          </Box>
+        </Box>
+      ))}
     </Box>
   );
 }

--- a/site/src/components/FieldTable.tsx
+++ b/site/src/components/FieldTable.tsx
@@ -15,77 +15,72 @@ export default function FieldTable({ fields, dwcTerms }: Props) {
   const entries = Object.entries(fields);
   return (
     <Box
-      component="table"
       sx={{
-        width: "100%",
-        borderCollapse: "collapse",
         mb: "36px",
         fontSize: "13px",
+        borderTop: `1px solid ${palette.rule}`,
       }}
     >
-      <tbody>
-        {entries.map(([name, prop], i) => {
-          const dwcName = FIELD_TO_DWC[name] ?? name;
-          const dwcTerm = !ATPROTO_FIELDS.has(name) ? dwcTerms[dwcName] : undefined;
-          return (
+      {entries.map(([name, prop]) => {
+        const dwcName = FIELD_TO_DWC[name] ?? name;
+        const dwcTerm = !ATPROTO_FIELDS.has(name) ? dwcTerms[dwcName] : undefined;
+        return (
+          <Box
+            key={name}
+            sx={{
+              borderBottom: `1px solid ${palette.ruleSoft}`,
+              display: "flex",
+              flexDirection: { xs: "column", sm: "row" },
+              alignItems: { sm: "flex-start" },
+              gap: { xs: "2px", sm: "12px" },
+              py: "10px",
+            }}
+          >
             <Box
-              key={name}
-              component="tr"
               sx={{
-                borderTop: i === 0 ? `1px solid ${palette.rule}` : "none",
-                borderBottom: `1px solid ${palette.ruleSoft}`,
+                fontFamily: fonts.mono,
+                fontSize: "12.5px",
+                color: palette.forest,
+                flex: { sm: "0 0 200px" },
+                overflowWrap: "anywhere",
               }}
             >
+              {name}
+              {prop.required && (
+                <Box component="span" sx={{ color: palette.warn, ml: "4px" }}>*</Box>
+              )}
+            </Box>
+            <Box sx={{ color: palette.inkSoft, flex: 1, minWidth: 0 }}>
+              {prop.description ?? ""}
               <Box
-                component="td"
                 sx={{
                   fontFamily: fonts.mono,
-                  fontSize: "12.5px",
-                  p: "10px 12px 10px 0",
-                  color: palette.forest,
-                  verticalAlign: "top",
-                  width: 200,
+                  fontSize: "10.5px",
+                  color: palette.inkFaint,
+                  mt: "3px",
+                  wordBreak: "break-word",
                 }}
               >
-                {name}
-                {prop.required && (
-                  <Box component="span" sx={{ color: palette.warn, ml: "4px" }}>*</Box>
+                {typeLabel(prop)}
+                {dwcTerm && (
+                  <>
+                    {" · "}
+                    <Box
+                      component="a"
+                      href={dwcTerm.term_iri}
+                      target="_blank"
+                      rel="noopener"
+                      sx={{ color: palette.inkFaint, textDecoration: "none" }}
+                    >
+                      dwc:{dwcTerm.name}
+                    </Box>
+                  </>
                 )}
               </Box>
-              <Box
-                component="td"
-                sx={{ p: "10px 12px", color: palette.inkSoft, verticalAlign: "top" }}
-              >
-                {prop.description ?? ""}
-                <Box
-                  sx={{
-                    fontFamily: fonts.mono,
-                    fontSize: "10.5px",
-                    color: palette.inkFaint,
-                    mt: "3px",
-                  }}
-                >
-                  {typeLabel(prop)}
-                  {dwcTerm && (
-                    <>
-                      {" · "}
-                      <Box
-                        component="a"
-                        href={dwcTerm.term_iri}
-                        target="_blank"
-                        rel="noopener"
-                        sx={{ color: palette.inkFaint, textDecoration: "none" }}
-                      >
-                        dwc:{dwcTerm.name}
-                      </Box>
-                    </>
-                  )}
-                </Box>
-              </Box>
             </Box>
-          );
-        })}
-      </tbody>
+          </Box>
+        );
+      })}
     </Box>
   );
 }

--- a/site/src/components/Layout.tsx
+++ b/site/src/components/Layout.tsx
@@ -32,11 +32,13 @@ export default function Layout() {
         sx={{
           maxWidth: 760,
           mx: "auto",
-          px: 4,
+          px: { xs: 2, sm: 3, md: 4 },
           pt: "30px",
           display: "flex",
           alignItems: "baseline",
-          gap: "20px",
+          flexWrap: "wrap",
+          rowGap: "10px",
+          columnGap: { xs: "14px", sm: "20px" },
           fontSize: "13.5px",
           color: palette.inkSoft,
         }}
@@ -103,11 +105,16 @@ export default function Layout() {
           </NavLink>
         ))}
 
-        <Box sx={{ flex: 1 }} />
+        <Box sx={{ flex: 1, display: { xs: "none", sm: "block" } }} />
 
         <Box
           component="span"
-          sx={{ fontFamily: fonts.mono, fontSize: "11px", color: palette.inkFaint }}
+          sx={{
+            fontFamily: fonts.mono,
+            fontSize: "11px",
+            color: palette.inkFaint,
+            ml: { xs: "auto", sm: 0 },
+          }}
         >
           v0.1-draft
         </Box>
@@ -124,7 +131,13 @@ export default function Layout() {
 
       <Box
         component="main"
-        sx={{ maxWidth: 760, mx: "auto", px: 4, pt: "48px", pb: "56px" }}
+        sx={{
+          maxWidth: 760,
+          mx: "auto",
+          px: { xs: 2, sm: 3, md: 4 },
+          pt: { xs: "32px", sm: "48px" },
+          pb: "56px",
+        }}
       >
         <Outlet />
       </Box>
@@ -134,7 +147,7 @@ export default function Layout() {
         sx={{
           maxWidth: 760,
           mx: "auto",
-          px: 4,
+          px: { xs: 2, sm: 3, md: 4 },
           pt: 3,
           pb: 6,
           borderTop: `1px solid ${palette.rule}`,
@@ -143,7 +156,8 @@ export default function Layout() {
           color: palette.inkFaint,
           display: "flex",
           flexWrap: "wrap",
-          gap: 3,
+          rowGap: 1.5,
+          columnGap: { xs: 2, sm: 3 },
           alignItems: "baseline",
         }}
       >

--- a/site/src/pages/LexiconPage.tsx
+++ b/site/src/pages/LexiconPage.tsx
@@ -23,7 +23,7 @@ export default function LexiconPage() {
         component="h2"
         sx={{
           fontFamily: fonts.serif,
-          fontSize: "24px",
+          fontSize: { xs: "20px", sm: "24px" },
           fontWeight: 600,
           letterSpacing: "-0.005em",
           m: "0 0 6px",
@@ -31,6 +31,7 @@ export default function LexiconPage() {
           borderTop: `1px solid ${palette.rule}`,
           pt: "32px",
           mt: 0,
+          overflowWrap: "anywhere",
         }}
       >
         <Box

--- a/site/src/pages/Overview.tsx
+++ b/site/src/pages/Overview.tsx
@@ -29,55 +29,40 @@ export default function Overview() {
       </Box>
 
       <Box
-        component="table"
         sx={{
-          width: "100%",
-          borderCollapse: "collapse",
           mb: "36px",
           fontSize: "13.5px",
         }}
       >
-        <tbody>
-          {MODELS.map((m) => (
+        {MODELS.map((m) => (
+          <Box
+            key={m.slug}
+            sx={{
+              borderBottom: `1px solid ${palette.ruleSoft}`,
+              display: "flex",
+              flexDirection: { xs: "column", sm: "row" },
+              alignItems: { sm: "flex-start" },
+              gap: { xs: "4px", sm: "14px" },
+              py: "12px",
+            }}
+          >
             <Box
-              key={m.slug}
-              component="tr"
-              sx={{ borderBottom: `1px solid ${palette.ruleSoft}` }}
+              component={Link}
+              to={`/${m.slug}`}
+              sx={{
+                fontFamily: fonts.mono,
+                fontSize: "12.5px",
+                color: palette.link,
+                textDecoration: "none",
+                flex: { sm: "0 0 260px" },
+                overflowWrap: "anywhere",
+              }}
             >
-              <Box
-                component="td"
-                sx={{
-                  p: "12px 14px 12px 0",
-                  verticalAlign: "top",
-                  width: 260,
-                }}
-              >
-                <Box
-                  component={Link}
-                  to={`/${m.slug}`}
-                  sx={{
-                    fontFamily: fonts.mono,
-                    fontSize: "12.5px",
-                    color: palette.link,
-                    textDecoration: "none",
-                  }}
-                >
-                  {m.lexicon.id}
-                </Box>
-              </Box>
-              <Box
-                component="td"
-                sx={{
-                  p: "12px 14px",
-                  color: palette.inkSoft,
-                  verticalAlign: "top",
-                }}
-              >
-                {m.description}
-              </Box>
+              {m.lexicon.id}
             </Box>
-          ))}
-        </tbody>
+            <Box sx={{ color: palette.inkSoft, flex: 1 }}>{m.description}</Box>
+          </Box>
+        ))}
       </Box>
 
       <SchemaGraph />


### PR DESCRIPTION
## Summary
- Site uses MUI but had fixed widths and a single-row nav that didn't adapt — converted layout, tables, and headings to use MUI's responsive `sx` breakpoints rather than introducing a new framework.
- Nav and footer wrap on overflow; horizontal padding scales `{xs: 2, sm: 3, md: 4}`; the version/GitHub group right-aligns on narrow viewports via `ml: auto`.
- Overview, FieldTable, and DwcAlignmentTable replace fixed-width `<td>` columns with flex rows that stack vertically on `xs` and split into two columns on `sm+`. Long NSIDs use `overflowWrap: "anywhere"` so they break cleanly. The redundant class column in the alignment table hides on `xs`.
- LexiconPage heading scales `{xs: "20px", sm: "24px"}` and wraps long NSIDs.

## Test plan
- [x] Verified at 375px viewport (iPhone) — nav wraps, tables stack name-above-description, footer wraps
- [x] Verified at 900px viewport (desktop) — preserves the original two-column table appearance
- [x] `tsc -b` passes
- [ ] Spot check at intermediate widths (tablet, ~600–760px) before merging