### PR TITLE
feat: support Occurrence user's accepted identification

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ See **[lexicons.bio](https://lexicons.bio)** for the full reference.
 ```bash
 cd site
 npm install
+npm run prebuild
 npm run dev
 ```
 

--- a/lexicons/bio/lexicons/temp/v0-1/identification.json
+++ b/lexicons/bio/lexicons/temp/v0-1/identification.json
@@ -32,6 +32,11 @@
             "description": "Taxonomic kingdom for disambiguating homonyms (Darwin Core dwc:kingdom).",
             "maxLength": 64
           },
+          "taxonID": {
+            "type": "string",
+            "format": "uri",
+            "description": "Stable URI for the identified taxon (e.g. a GBIF species URI). Maps to Darwin Core dwc:taxonID."
+          },
           "identificationRemarks": {
             "type": "string",
             "description": "Explanation or reasoning for this identification (Darwin Core dwc:identificationRemarks).",

--- a/lexicons/bio/lexicons/temp/v0-1/occurrence.json
+++ b/lexicons/bio/lexicons/temp/v0-1/occurrence.json
@@ -39,12 +39,12 @@
           "taxonID": {
             "type": "string",
             "format": "uri",
-            "description": "Identified taxon the occurrence user has accepted, preferably a stable URI (e.g. a GBIF species URI). Derived from identification specified by acceptedIdentificationID. Should not be present without acceptedIdentificationID. Represents a more specific version of the DarwinCore equivalent (Darwin Core dwc:taxonID)."
+            "description": "Identified taxon the occurrence user has accepted, preferably a stable URI (e.g. a GBIF species URI). Derived from identification specified by acceptedIdentificationID. Must be accompanied by acceptedIdentificationID. Represents a more specific version of the DarwinCore equivalent (Darwin Core dwc:taxonID)."
           },
           "acceptedIdentificationID": {
             "type": "ref",
             "ref": "com.atproto.repo.strongRef",
-            "description": "Identification accepted by the occurrence user as the source of taxonID. Should not be present without taxonID. Indirectly maps to Darwin Core dwc:isAcceptedIdentification."
+            "description": "Identification accepted by the occurrence user as the source of taxonID. Must be accompanied by taxonID. Indirectly maps to Darwin Core dwc:isAcceptedIdentification."
           }
         }
       }

--- a/lexicons/bio/lexicons/temp/v0-1/occurrence.json
+++ b/lexicons/bio/lexicons/temp/v0-1/occurrence.json
@@ -44,7 +44,7 @@
           "acceptedIdentificationID": {
             "type": "ref",
             "ref": "com.atproto.repo.strongRef",
-            "description": "Strong reference to the Identification accepted by the occurrence user as the source of taxonID. Should not be present without taxonID. A strongRef is used so that if the underlying Identification record changes (e.g. its taxon is updated), consumers can detect that taxonID may need to be re-derived. Indirectly maps to Darwin Core dwc:isAcceptedIdentification — because in ATProto only the Identification's author can edit that flag, the relationship is instead expressed from the Occurrence side."
+            "description": "Identification accepted by the occurrence user as the source of taxonID. Should not be present without taxonID. Indirectly maps to Darwin Core dwc:isAcceptedIdentification."
           }
         }
       }

--- a/lexicons/bio/lexicons/temp/v0-1/occurrence.json
+++ b/lexicons/bio/lexicons/temp/v0-1/occurrence.json
@@ -35,6 +35,16 @@
               "ref": "com.atproto.repo.strongRef"
             },
             "maxLength": 10
+          },
+          "taxonID": {
+            "type": "string",
+            "format": "uri",
+            "description": "Identified taxon the occurrence user has accepted, preferably a stable URI (e.g. a GBIF species URI). Derived from identification specified by identificationID. Should not be present withough identificationID. Represents a more specific version of the DarwinCore equivalent."
+          },
+          "identificationID": {
+            "type": "string",
+            "format": "at-uri",
+            "description": "Identification accepted by the occurrence user as the source of taxonID. Should not be present without taxonID."
           }
         }
       }

--- a/lexicons/bio/lexicons/temp/v0-1/occurrence.json
+++ b/lexicons/bio/lexicons/temp/v0-1/occurrence.json
@@ -39,12 +39,12 @@
           "taxonID": {
             "type": "string",
             "format": "uri",
-            "description": "Identified taxon the occurrence user has accepted, preferably a stable URI (e.g. a GBIF species URI). Derived from identification specified by identificationID. Should not be present withough identificationID. Represents a more specific version of the DarwinCore equivalent."
+            "description": "Identified taxon the occurrence user has accepted, preferably a stable URI (e.g. a GBIF species URI). Derived from identification specified by acceptedIdentificationID. Should not be present without acceptedIdentificationID. Represents a more specific version of the DarwinCore equivalent (Darwin Core dwc:taxonID)."
           },
-          "identificationID": {
-            "type": "string",
-            "format": "at-uri",
-            "description": "Identification accepted by the occurrence user as the source of taxonID. Should not be present without taxonID."
+          "acceptedIdentificationID": {
+            "type": "ref",
+            "ref": "com.atproto.repo.strongRef",
+            "description": "Strong reference to the Identification accepted by the occurrence user as the source of taxonID. Should not be present without taxonID. A strongRef is used so that if the underlying Identification record changes (e.g. its taxon is updated), consumers can detect that taxonID may need to be re-derived. Indirectly maps to Darwin Core dwc:isAcceptedIdentification — because in ATProto only the Identification's author can edit that flag, the relationship is instead expressed from the Occurrence side."
           }
         }
       }

--- a/site/src/data/lexicons.ts
+++ b/site/src/data/lexicons.ts
@@ -76,6 +76,8 @@ export const MODELS: ModelConfig[] = [
         decimalLatitude: "37.8716",
         decimalLongitude: "-122.2727",
         coordinateUncertaintyInMeters: 15,
+        taxonID: "https://www.gbif.org/species/2880791",
+        identificationID: "at://did:plc:abc123.../bio.lexicons.temp.v0-1.identification/3k...",
         associatedMedia: [
           {
             uri: "at://did:plc:abc123.../bio.lexicons.temp.v0-1.media/3k...",

--- a/site/src/data/lexicons.ts
+++ b/site/src/data/lexicons.ts
@@ -180,6 +180,7 @@ export const ATPROTO_FIELDS = new Set([
   "aspectRatio",
   "width",
   "height",
+  "acceptedIdentificationID",
 ]);
 
 /** GBIF publishing requirements */

--- a/site/src/data/lexicons.ts
+++ b/site/src/data/lexicons.ts
@@ -77,7 +77,10 @@ export const MODELS: ModelConfig[] = [
         decimalLongitude: "-122.2727",
         coordinateUncertaintyInMeters: 15,
         taxonID: "https://www.gbif.org/species/2880791",
-        identificationID: "at://did:plc:abc123.../bio.lexicons.temp.v0-1.identification/3k...",
+        acceptedIdentificationID: {
+          uri: "at://did:plc:abc123.../bio.lexicons.temp.v0-1.identification/3k...",
+          cid: "bafyrei...",
+        },
         associatedMedia: [
           {
             uri: "at://did:plc:abc123.../bio.lexicons.temp.v0-1.media/3k...",
@@ -156,6 +159,7 @@ export const MODELS: ModelConfig[] = [
         },
         scientificName: "Aphelocoma californica (Vigors, 1839)",
         taxonRank: "species",
+        taxonID: "https://www.gbif.org/species/2880791",
         identificationRemarks:
           "Blue head and wings, white eyebrow, gray-brown back — classic California Scrub-Jay",
       },


### PR DESCRIPTION
Adds `taxonID` and `acceptedIdentificationID` to Occurrence, which represent the Occurence user's *preferred* taxon and Identification for their Occurrence. This drifts slightly from the preference to restrict taxon info to Identification records, but it captures a level of user intent that I think is important. Consumers of the Occurrence are free to associate an Occurrence with the taxon of their choosing (from an Identification or not), but the owner of the Occurrence probably wants to think about it as being linked to a single identification/taxon, as in "this is my observation of a Pileated Woodpecker" and not "this is my observation of something about which there are many opinions." In addition to matching how people think about this data, it increases portability and integrity in situations where another user might delete their identifications.

This came out of my work on https://github.com/Cuanto-bio/cuanto.bio, where Occurrence records are only potentially linked to taxa via SurveyTarget records that the owner of the Occurrence does not control. I was concerned about a situation where you complete a Survey that is linked to a bunch of Occurrences, but then the author the Protocol you were following deletes the Protocol and all its SurveyTargets. It's not absolutely required by the Cuanto use case, and it pushes against the stated desire to leave taxon stuff to the Identification, hence the separate PR.


This also adds `taxonID` to Identification for consistency and linking identifications to externally defined taxa.