### PR TITLE
Address #29 review feedback: rename to acceptedIdentificationID, use strongRef, add taxonID to Identification

### DIFF
--- a/lexicons/bio/lexicons/temp/v0-1/identification.json
+++ b/lexicons/bio/lexicons/temp/v0-1/identification.json
@@ -32,6 +32,11 @@
             "description": "Taxonomic kingdom for disambiguating homonyms (Darwin Core dwc:kingdom).",
             "maxLength": 64
           },
+          "taxonID": {
+            "type": "string",
+            "format": "uri",
+            "description": "Stable URI for the identified taxon (e.g. a GBIF species URI). Maps to Darwin Core dwc:taxonID."
+          },
           "identificationRemarks": {
             "type": "string",
             "description": "Explanation or reasoning for this identification (Darwin Core dwc:identificationRemarks).",

--- a/lexicons/bio/lexicons/temp/v0-1/occurrence.json
+++ b/lexicons/bio/lexicons/temp/v0-1/occurrence.json
@@ -44,7 +44,7 @@
           "acceptedIdentificationID": {
             "type": "ref",
             "ref": "com.atproto.repo.strongRef",
-            "description": "Strong reference to the Identification accepted by the occurrence user as the source of taxonID. Should not be present without taxonID. A strongRef is used so that if the underlying Identification record changes (e.g. its taxon is updated), consumers can detect that taxonID may need to be re-derived. Indirectly maps to Darwin Core dwc:isAcceptedIdentification — because in ATProto only the Identification's author can edit that flag, the relationship is instead expressed from the Occurrence side."
+            "description": "Identification accepted by the occurrence user as the source of taxonID. Should not be present without taxonID. Indirectly maps to Darwin Core dwc:isAcceptedIdentification."
           }
         }
       }

--- a/lexicons/bio/lexicons/temp/v0-1/occurrence.json
+++ b/lexicons/bio/lexicons/temp/v0-1/occurrence.json
@@ -39,12 +39,12 @@
           "taxonID": {
             "type": "string",
             "format": "uri",
-            "description": "Identified taxon the occurrence user has accepted, preferably a stable URI (e.g. a GBIF species URI). Derived from identification specified by identificationID. Should not be present withough identificationID. Represents a more specific version of the DarwinCore equivalent."
+            "description": "Identified taxon the occurrence user has accepted, preferably a stable URI (e.g. a GBIF species URI). Derived from identification specified by acceptedIdentificationID. Should not be present without acceptedIdentificationID. Represents a more specific version of the DarwinCore equivalent (Darwin Core dwc:taxonID)."
           },
-          "identificationID": {
-            "type": "string",
-            "format": "at-uri",
-            "description": "Identification accepted by the occurrence user as the source of taxonID. Should not be present without taxonID."
+          "acceptedIdentificationID": {
+            "type": "ref",
+            "ref": "com.atproto.repo.strongRef",
+            "description": "Strong reference to the Identification accepted by the occurrence user as the source of taxonID. Should not be present without taxonID. A strongRef is used so that if the underlying Identification record changes (e.g. its taxon is updated), consumers can detect that taxonID may need to be re-derived. Indirectly maps to Darwin Core dwc:isAcceptedIdentification — because in ATProto only the Identification's author can edit that flag, the relationship is instead expressed from the Occurrence side."
           }
         }
       }

--- a/site/src/data/lexicons.ts
+++ b/site/src/data/lexicons.ts
@@ -77,7 +77,10 @@ export const MODELS: ModelConfig[] = [
         decimalLongitude: "-122.2727",
         coordinateUncertaintyInMeters: 15,
         taxonID: "https://www.gbif.org/species/2880791",
-        identificationID: "at://did:plc:abc123.../bio.lexicons.temp.v0-1.identification/3k...",
+        acceptedIdentificationID: {
+          uri: "at://did:plc:abc123.../bio.lexicons.temp.v0-1.identification/3k...",
+          cid: "bafyrei...",
+        },
         associatedMedia: [
           {
             uri: "at://did:plc:abc123.../bio.lexicons.temp.v0-1.media/3k...",
@@ -156,6 +159,7 @@ export const MODELS: ModelConfig[] = [
         },
         scientificName: "Aphelocoma californica (Vigors, 1839)",
         taxonRank: "species",
+        taxonID: "https://www.gbif.org/species/2880791",
         identificationRemarks:
           "Blue head and wings, white eyebrow, gray-brown back — classic California Scrub-Jay",
       },


### PR DESCRIPTION
Stacks on #29 to address review feedback there.

- Fix `withough` → `without` typo
- Rename `Occurrence.identificationID` → `acceptedIdentificationID` and switch to `com.atproto.repo.strongRef`
- Add `taxonID` to Identification (maps to `dwc-dp.Identification.taxonID`)
- Update site examples