### PR TITLE
Rename Occurrence.associatedMedia to media

### DIFF
--- a/lexicons/bio/lexicons/temp/v0-1/occurrence.json
+++ b/lexicons/bio/lexicons/temp/v0-1/occurrence.json
@@ -29,7 +29,7 @@
           },
           "media": {
             "type": "array",
-            "description": "Strong references to media records documenting the observation. Replaces the old Darwin Core dwc:associatedMedia term, which DwC-DP dropped in favor of an occurrence-media join.",
+            "description": "Strong references to media records documenting the observation (Darwin Core dwc:associatedMedia).",
             "items": {
               "type": "ref",
               "ref": "com.atproto.repo.strongRef"

--- a/lexicons/bio/lexicons/temp/v0-1/occurrence.json
+++ b/lexicons/bio/lexicons/temp/v0-1/occurrence.json
@@ -29,7 +29,7 @@
           },
           "media": {
             "type": "array",
-            "description": "Strong references to media records documenting the observation (Darwin Core dwc:associatedMedia).",
+            "description": "Strong references to media records documenting the observation. Conceptually maps to the DwC-DP Media table (https://gbif.github.io/dwc-dp/qrg/#Media), which replaced the legacy dwc:associatedMedia term.",
             "items": {
               "type": "ref",
               "ref": "com.atproto.repo.strongRef"

--- a/lexicons/bio/lexicons/temp/v0-1/occurrence.json
+++ b/lexicons/bio/lexicons/temp/v0-1/occurrence.json
@@ -27,9 +27,9 @@
             "description": "The horizontal distance (in meters) from the given coordinates describing the smallest circle containing the whole of the Location (Darwin Core dwc:coordinateUncertaintyInMeters).",
             "minimum": 0
           },
-          "associatedMedia": {
+          "media": {
             "type": "array",
-            "description": "Strong references to media records documenting the observation (Darwin Core dwc:associatedMedia).",
+            "description": "Strong references to media records documenting the observation. Replaces the old Darwin Core dwc:associatedMedia term, which DwC-DP dropped in favor of an occurrence-media join.",
             "items": {
               "type": "ref",
               "ref": "com.atproto.repo.strongRef"

--- a/lexicons/bio/lexicons/temp/v0-1/occurrence.json
+++ b/lexicons/bio/lexicons/temp/v0-1/occurrence.json
@@ -29,7 +29,7 @@
           },
           "media": {
             "type": "array",
-            "description": "Strong references to media records documenting the observation. Conceptually maps to the DwC-DP Media table (https://gbif.github.io/dwc-dp/qrg/#Media), which replaced the legacy dwc:associatedMedia term.",
+            "description": "Strong references to media records documenting the observation. Conceptually maps to the DwC-DP Occurrence Media table (https://gbif.github.io/dwc-dp/qrg/#Occurrence%20Media), which replaced the legacy dwc:associatedMedia term.",
             "items": {
               "type": "ref",
               "ref": "com.atproto.repo.strongRef"

--- a/site/src/data/lexicons.ts
+++ b/site/src/data/lexicons.ts
@@ -76,7 +76,7 @@ export const MODELS: ModelConfig[] = [
         decimalLatitude: "37.8716",
         decimalLongitude: "-122.2727",
         coordinateUncertaintyInMeters: 15,
-        associatedMedia: [
+        media: [
           {
             uri: "at://did:plc:abc123.../bio.lexicons.temp.v0-1.media/3k...",
             cid: "bafyrei...",


### PR DESCRIPTION
Closes #21.

`dwc:associatedMedia` was a pipe-delimited URI string in old Darwin Core. DwC-DP replaced it with an `occurrence-media` join and dropped the term entirely, so the field name was a holdover. The shorter `media` name better reflects how the field is actually used (an array of `strongRef`).

## Test plan
- [ ] `cd site && npm run prebuild && npx tsc -b` passes (verified locally)
- [ ] Occurrence page on the site renders the renamed field