### PR TITLE
Render per-def field tables, knownValues, scrollbar fix

### DIFF
--- a/site/src/components/FieldTable.tsx
+++ b/site/src/components/FieldTable.tsx
@@ -77,6 +77,20 @@ export default function FieldTable({ fields, dwcTerms }: Props) {
                   </>
                 )}
               </Box>
+              {prop.knownValues && (
+                <Box
+                  sx={{
+                    fontFamily: fonts.mono,
+                    fontSize: "10.5px",
+                    color: palette.inkFaint,
+                    mt: "3px",
+                    wordBreak: "break-word",
+                  }}
+                >
+                  <strong>{"Known values: "}</strong>
+                  {prop.knownValues.join(", ")}
+                </Box>
+              )}
             </Box>
           </Box>
         );

--- a/site/src/pages/LexiconPage.tsx
+++ b/site/src/pages/LexiconPage.tsx
@@ -2,7 +2,7 @@ import { useParams, Navigate } from "react-router-dom";
 import { Box } from "@mui/material";
 import FieldTable from "../components/FieldTable";
 import DwcAlignmentTable from "../components/DwcAlignmentTable";
-import { MODELS, getFlatProperties } from "../data/lexicons";
+import { MODELS, getFlatProperties, getDefProperties } from "../data/lexicons";
 import { dwcTerms } from "../data/dwcTerms";
 import { palette, fonts } from "../theme";
 
@@ -12,6 +12,14 @@ export default function LexiconPage() {
   if (!model) return <Navigate to="/" replace />;
 
   const lexProps = getFlatProperties(model.lexicon);
+
+  const mainDef = model.lexicon.defs["main"];
+  const { properties: mainProps, required: mainRequired } = getDefProperties(mainDef);
+  const mainFields = Object.fromEntries(
+    Object.entries(mainProps).map(([k, v]) => [k, { ...v, required: mainRequired.has(k), def: "main" }])
+  );
+
+  const otherDefs = Object.entries(model.lexicon.defs).filter(([name]) => name !== "main");
   const lexId = model.lexicon.id;
   const lastDot = lexId.lastIndexOf(".");
   const nsidPrefix = lexId.slice(0, lastDot + 1);
@@ -62,7 +70,36 @@ export default function LexiconPage() {
         {model.description}
       </Box>
 
-      <FieldTable fields={lexProps} dwcTerms={dwcTerms} />
+      <FieldTable fields={mainFields} dwcTerms={dwcTerms} />
+
+      {otherDefs.map(([defName, defBody]) => {
+        const { properties, required } = getDefProperties(defBody);
+        const fields = Object.fromEntries(
+          Object.entries(properties).map(([k, v]) => [k, { ...v, required: required.has(k), def: defName }])
+        );
+        return (
+          <Box key={defName} sx={{ mb: "36px" }}>
+            <Box
+              component="h4"
+              sx={{
+                fontFamily: fonts.mono,
+                fontSize: "13px",
+                fontWeight: 500,
+                color: palette.inkSoft,
+                m: "0 0 4px",
+              }}
+            >
+              #{defName}
+            </Box>
+            {defBody.description && (
+              <Box sx={{ fontSize: "13px", color: palette.inkSoft, mb: "12px" }}>
+                {defBody.description}
+              </Box>
+            )}
+            <FieldTable fields={fields} dwcTerms={dwcTerms} />
+          </Box>
+        );
+      })}
 
       <Box
         component="pre"

--- a/site/src/theme.ts
+++ b/site/src/theme.ts
@@ -38,6 +38,9 @@ export const theme = createTheme({
   components: {
     MuiCssBaseline: {
       styleOverrides: {
+        html: {
+          overflowY: "scroll", // prevents layout shift when navigating between short and tall pages
+        },
         body: {
           background: palette.bg,
           color: palette.ink,


### PR DESCRIPTION
## Summary
Three small rendering fixes for the lexicon docs site, extracted from #32 so they can land independently of the survey lexicons. All three address existing gaps on `main`:

- **`LexiconPage.tsx`** — Render each lexicon `def` as its own section (with the def name and description), instead of flattening every def's fields into one table. Surfaces `media.json`'s `#aspectRatio` def (width/height), which is currently merged into the main field list with no indication it lives in a sub-def.
- **`FieldTable.tsx`** — Display a "Known values: ..." line under fields that declare `knownValues`. `media.format` and `identification.taxonRank` both declare `knownValues` today that the site silently drops.
- **`theme.ts`** — `html { overflow-y: scroll }` so navigating between short and tall lexicon pages doesn't reflow horizontally as the scrollbar appears/disappears.

Authored by @kueda in #32; pulled out here for easier review.

## Test plan
- [x] `/media` shows a `#aspectRatio` section with width/height beneath the main fields
- [x] `/media` shows "Known values: ..." under `format`
- [x] `/identification` shows "Known values: ..." under `taxonRank`
- [x] Navigating between `/` and a longer lexicon page no longer jiggles horizontally