### PR TITLE
feat: add organismQuantity and organismQuantityType to Occurrence

### DIFF
--- a/lexicons/bio/lexicons/temp/v0-1/occurrence.json
+++ b/lexicons/bio/lexicons/temp/v0-1/occurrence.json
@@ -36,6 +36,16 @@
             },
             "maxLength": 10
           },
+          "organismQuantity": {
+            "type": "string",
+            "description": "The quantity of the organism present at the time of the Occurrence. Generally an integer or float but may be categorical, e.g. 'many' or '10-100' (Darwin Core dwc:organismQuantity)."
+          },
+          "organismQuantityType": {
+            "type": "string",
+            "description": "The type of quantification system used for the quantity of organisms (Darwin Core dwc:organismQuantityType).",
+            "knownValues": ["individual-count", "percent-cover"],
+            "default": "individual-count"
+          },
           "taxonID": {
             "type": "string",
             "format": "uri",

--- a/lexicons/bio/lexicons/temp/v0-1/occurrence.json
+++ b/lexicons/bio/lexicons/temp/v0-1/occurrence.json
@@ -43,8 +43,7 @@
           "organismQuantityType": {
             "type": "string",
             "description": "The type of quantification system used for the quantity of organisms (Darwin Core dwc:organismQuantityType).",
-            "knownValues": ["individual-count", "percent-cover"],
-            "default": "individual-count"
+            "knownValues": ["individuals", "percent-cover"]
           },
           "taxonID": {
             "type": "string",


### PR DESCRIPTION
## Summary

- Adds `organismQuantity` and `organismQuantityType` to the Occurrence lexicon.
- Stable Darwin Core terms (`dwc:organismQuantity`, `dwc:organismQuantityType`) shared across DwC-A and DwC-DP — not Humboldt-specific, not DwC-DP-specific.
- Extracted from #32 (credit: @kueda) to land independently of the Survey/SurveyProtocol/SurveyTarget discussion, which still needs resolving (namespace, Protocol-vs-Survey target attachment, etc.).

Description text was lightly edited from the original to match the project's `(Darwin Core dwc:X)` convention used by every other field in `occurrence.json`. Field types and `knownValues` are unchanged from @kueda's original.

## Test plan

- [ ] Verify the site renders the two new fields in the Occurrence lexicon page.
- [ ] Decide on `organismQuantityType.knownValues` before marking ready-for-review.
- [ ] Confirm `organismQuantity` + `organismQuantityType` show up under the DwC-DP alignment table as mapped terms.