### PR TITLE
Migrate Media license from SPDX identifiers to license URIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ NSIDs include the version as a segment (e.g. `bio.lexicons.temp.v0-1.occurrence`
 The `temp.` prefix marks the schemas as not yet stable — breaking changes may
 ship in subsequent versions until the prefix is dropped.
 
+## [Unreleased]
+
+### Changed
+- `bio.lexicons.temp.v0-1.media.license` — replace SPDX identifiers
+  (`CC-BY-4.0`, …) with license URIs
+  (`https://creativecommons.org/licenses/by/4.0/`, …). SPDX is primarily
+  a software-license vocabulary, while Dublin Core `dcterms:license`
+  expects a URI of the license document. Closes #15.
+
 ## [0.1] — 2026-04-27
 
 Initial tagged release. Three record types under `bio.lexicons.temp.v0-1.*`.

--- a/lexicons/bio/lexicons/temp/v0-1/media.json
+++ b/lexicons/bio/lexicons/temp/v0-1/media.json
@@ -27,7 +27,6 @@
           },
           "license": {
             "type": "string",
-            "format": "uri",
             "description": "URI of the license under which this media is published (Dublin Core dcterms:license). Creative Commons license URIs are the recommended values.",
             "knownValues": [
               "https://creativecommons.org/publicdomain/zero/1.0/",

--- a/lexicons/bio/lexicons/temp/v0-1/media.json
+++ b/lexicons/bio/lexicons/temp/v0-1/media.json
@@ -27,15 +27,16 @@
           },
           "license": {
             "type": "string",
-            "description": "SPDX license identifier for this media (maps to Dublin Core dcterms:license).",
+            "format": "uri",
+            "description": "URI of the license under which this media is published (Dublin Core dcterms:license). Creative Commons license URIs are the recommended values.",
             "knownValues": [
-              "CC0-1.0",
-              "CC-BY-4.0",
-              "CC-BY-NC-4.0",
-              "CC-BY-SA-4.0",
-              "CC-BY-NC-SA-4.0"
+              "https://creativecommons.org/publicdomain/zero/1.0/",
+              "https://creativecommons.org/licenses/by/4.0/",
+              "https://creativecommons.org/licenses/by-nc/4.0/",
+              "https://creativecommons.org/licenses/by-sa/4.0/",
+              "https://creativecommons.org/licenses/by-nc-sa/4.0/"
             ],
-            "maxLength": 32
+            "maxLength": 128
           }
         }
       }

--- a/site/src/data/lexicons.ts
+++ b/site/src/data/lexicons.ts
@@ -109,7 +109,7 @@ export const MODELS: ModelConfig[] = [
           size: 204800,
         },
         alt: "California Scrub-Jay perched on oak branch",
-        license: "CC-BY-4.0",
+        license: "https://creativecommons.org/licenses/by/4.0/",
       },
       null,
       2
@@ -125,7 +125,7 @@ export const MODELS: ModelConfig[] = [
         },
         alt: "California Scrub-Jay perched on oak branch",
         aspectRatio: { width: 4032, height: 3024 },
-        license: "CC-BY-4.0",
+        license: "https://creativecommons.org/licenses/by/4.0/",
       },
       null,
       2


### PR DESCRIPTION
## Summary

- Replaces SPDX identifiers (`CC-BY-4.0`, `CC0-1.0`, …) in `bio.lexicons.temp.v0-1.media.license` with canonical Creative Commons URIs.
- Updates the field's description to reference Dublin Core `dcterms:license`'s expectation of a license-document URI.
- Bumps `maxLength` from 32 → 128 to fit URI values with headroom.
- Updates the two example license values in `site/src/data/lexicons.ts`.
- Adds a `[Unreleased]` section to `CHANGELOG.md` (the `[0.1]` historical entry is left untouched since it accurately describes what 0.1 shipped with).

## Motivation

Per #15: SPDX is primarily a software-license vocabulary. Dublin Core `dcterms:license` — which `media.license` maps to — expects a URI of the license document. Switching to canonical CC URIs aligns with both the standard and @kueda's preference expressed in the issue.

## Notes

- The field stays a plain `string` (no `format: "uri"`) so non-URI declarations like "all rights reserved" remain expressible. `knownValues` continues to advertise the recommended set without forcing it.
- New `knownValues` cover the same five CC variants the SPDX list did: CC0, CC BY, CC BY-NC, CC BY-SA, CC BY-NC-SA, all at v4.0.

Closes #15.

## Test plan

- [x] Verify the site renders the new URI `knownValues` correctly on the Media lexicon page.
- [x] Confirm the Media example block displays the new license URI.