### PR TITLE
Remove datetime format from Occurrence eventDate

### DIFF
--- a/lexicons/bio/lexicons/temp/v0-1/occurrence.json
+++ b/lexicons/bio/lexicons/temp/v0-1/occurrence.json
@@ -11,8 +11,7 @@
         "properties": {
           "eventDate": {
             "type": "string",
-            "format": "datetime",
-            "description": "The date-time when the observation occurred, in ISO 8601 format (Darwin Core dwc:eventDate)."
+            "description": "The date, date-time, or interval during which the dwc:Event occurred (Darwin Core dwc:eventDate). Recommended best practice is to use a value that conforms to ISO 8601-1:2019 for single dates or date-times, or to ISO 8601-2:2019 (EDTF) for intervals and dates of reduced or uncertain precision; separate the start and end of an interval with a solidus (\"/\"). Include timezone information whenever a time of day is given. Examples: \"1963-03-08\", \"1971\", \"1906-06\", \"1963-03-08T14:07:00-06:00\", \"1995-05-21/1995-05-23\"."
           },
           "decimalLatitude": {
             "type": "string",


### PR DESCRIPTION
Resolves #36.

## Problem
The Occurrence lexicon declares `eventDate` with atproto's `"format": "datetime"`, which requires a full-precision date-time **with timezone** (e.g. `1963-03-08T14:07:00-06:00`). But this field mirrors Darwin Core's [`dwc:eventDate`](https://gbif.github.io/dwc-dp/qrg/#Event__eventDate), which is intentionally permissive — it allows reduced precision (`1971`, `1906-06`) and time intervals.

As noted in #36, this blocks real data: a Cuanto.bio Occurrence can represent all individuals of a taxon seen over a survey that spans a period of time, with no single honest timestamp to record.

## Change
- Remove `"format": "datetime"` so the field accepts dates, date-times, and intervals.
- Rewrite the description to recommend ISO 8601-1:2019 for single dates/times and ISO 8601-2:2019 (EDTF) for intervals and reduced/uncertain precision, mirroring how the DwC spec words its guidance, with examples.

## Notes
- Validation is now advisory (in prose) rather than enforced by atproto. If we want to enforce a subset of formats, a `pattern` regex could be added as a follow-up.
- The field was effectively unused (records were leaving it unset), so loosening it should not affect existing data.