### PR TITLE
Add identifiedBy agent union (single object variant)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ NSIDs include the version as a segment (e.g. `bio.lexicons.temp.v0-1.occurrence`
 The `temp.` prefix marks the schemas as not yet stable — breaking changes may
 ship in subsequent versions until the prefix is dropped.
 
+## [Unreleased]
+
+### Added
+- `bio.lexicons.temp.v0-1.defs` — shared definitions lexicon. Introduces an
+  `agent` object def (Darwin Core `dcterms:Agent`) with `agentType`
+  (person/group/organization/machine/software, per tdwg/dwc#614), `name`,
+  `did`, and `identifier`.
+- `bio.lexicons.temp.v0-1.identification` — `identifiedBy` field
+  (Darwin Core `dwc:identifiedBy`), modeled as an open `union` with a single
+  variant (`defs#agent`) so additional variants (e.g. a strongRef to a
+  standalone agent record) can be added without a breaking change.
+
 ## [0.1] — 2026-04-27
 
 Initial tagged release. Three record types under `bio.lexicons.temp.v0-1.*`.

--- a/lexicons/bio/lexicons/temp/v0-1/defs.json
+++ b/lexicons/bio/lexicons/temp/v0-1/defs.json
@@ -1,0 +1,34 @@
+{
+  "lexicon": 1,
+  "id": "bio.lexicons.temp.v0-1.defs",
+  "defs": {
+    "agent": {
+      "type": "object",
+      "description": "A person, group, organization, machine, or software that played a role in producing a record (Darwin Core dcterms:Agent).",
+      "properties": {
+        "agentType": {
+          "type": "string",
+          "description": "The category that best matches the nature of the agent (Darwin Core dwc:agentType; see tdwg/dwc#614). Best practice is to use a controlled vocabulary.",
+          "knownValues": ["person", "group", "organization", "machine", "software"],
+          "maxLength": 32
+        },
+        "name": {
+          "type": "string",
+          "description": "Display name of the agent — a person or organization name, a device or camera label, or a model name.",
+          "maxLength": 256
+        },
+        "did": {
+          "type": "string",
+          "format": "did",
+          "description": "The atproto DID of the agent, when the agent is itself an account on the network."
+        },
+        "identifier": {
+          "type": "string",
+          "format": "uri",
+          "description": "A resolvable external identifier for the agent (e.g. an ORCID iD URI, a Wikidata URI, or a device/model URI). Maps to the Darwin Core ID-form terms such as dwc:identifiedByID.",
+          "maxLength": 512
+        }
+      }
+    }
+  }
+}

--- a/lexicons/bio/lexicons/temp/v0-1/identification.json
+++ b/lexicons/bio/lexicons/temp/v0-1/identification.json
@@ -41,6 +41,11 @@
             "type": "string",
             "description": "Explanation or reasoning for this identification (Darwin Core dwc:identificationRemarks).",
             "maxLength": 3000
+          },
+          "identifiedBy": {
+            "type": "union",
+            "refs": ["bio.lexicons.temp.v0-1.defs#agent"],
+            "description": "The agent responsible for this identification (Darwin Core dwc:identifiedBy). Modeled as an open union so further variants (e.g. a strong reference to a standalone agent record) can be added later without a breaking change. The only current variant is an inline agent object; use agentType \"software\" for model-generated identifications."
           }
         }
       }

--- a/lexicons/bio/lexicons/temp/v0-1/identification.json
+++ b/lexicons/bio/lexicons/temp/v0-1/identification.json
@@ -45,7 +45,7 @@
           "identifiedBy": {
             "type": "union",
             "refs": ["bio.lexicons.temp.v0-1.defs#agent"],
-            "description": "The agent responsible for this identification (Darwin Core dwc:identifiedBy). Modeled as an open union so further variants (e.g. a strong reference to a standalone agent record) can be added later without a breaking change. The only current variant is an inline agent object; use agentType \"software\" for model-generated identifications."
+            "description": "The agent responsible for this identification (Darwin Core dwc:identifiedBy). Open union so more variants can be added later; currently an inline agent object."
           }
         }
       }

--- a/site/src/components/FieldTable.tsx
+++ b/site/src/components/FieldTable.tsx
@@ -1,6 +1,13 @@
 import { Box } from "@mui/material";
 import type { LexiconProperty } from "../data/lexicons";
-import { typeLabel, FIELD_TO_DWC, ATPROTO_FIELDS } from "../data/lexicons";
+import {
+  typeLabel,
+  FIELD_TO_DWC,
+  ATPROTO_FIELDS,
+  refsOf,
+  resolveRef,
+  getDefProperties,
+} from "../data/lexicons";
 import type { DwcTerm } from "../data/dwcTerms";
 import { palette, fonts } from "../theme";
 
@@ -91,6 +98,95 @@ export default function FieldTable({ fields, dwcTerms }: Props) {
                   {prop.knownValues.join(", ")}
                 </Box>
               )}
+              {refsOf(prop)
+                .map((ref) => ({ ref, def: resolveRef(ref) }))
+                .filter((r) => r.def)
+                .map(({ ref, def }) => {
+                  const refName = ref.includes("#")
+                    ? ref.split("#").pop()!
+                    : ref;
+                  const { properties, required } = getDefProperties(def!);
+                  return (
+                    <Box
+                      key={ref}
+                      sx={{
+                        mt: "8px",
+                        pl: "12px",
+                        borderLeft: `2px solid ${palette.ruleSoft}`,
+                      }}
+                    >
+                      <Box
+                        sx={{
+                          fontFamily: fonts.mono,
+                          fontSize: "10.5px",
+                          color: palette.inkFaint,
+                          mb: "4px",
+                        }}
+                      >
+                        {refName}
+                      </Box>
+                      {Object.entries(properties).map(([subName, subProp]) => (
+                        <Box
+                          key={subName}
+                          sx={{
+                            display: "flex",
+                            flexDirection: { xs: "column", sm: "row" },
+                            gap: { xs: "1px", sm: "10px" },
+                            py: "4px",
+                          }}
+                        >
+                          <Box
+                            sx={{
+                              fontFamily: fonts.mono,
+                              fontSize: "11.5px",
+                              color: palette.forest,
+                              flex: { sm: "0 0 150px" },
+                              overflowWrap: "anywhere",
+                            }}
+                          >
+                            {subName}
+                            {required.has(subName) && (
+                              <Box
+                                component="span"
+                                sx={{ color: palette.warn, ml: "4px" }}
+                              >
+                                *
+                              </Box>
+                            )}
+                          </Box>
+                          <Box sx={{ flex: 1, minWidth: 0, fontSize: "12.5px" }}>
+                            {subProp.description ?? ""}
+                            <Box
+                              sx={{
+                                fontFamily: fonts.mono,
+                                fontSize: "10px",
+                                color: palette.inkFaint,
+                                mt: "2px",
+                                wordBreak: "break-word",
+                              }}
+                            >
+                              {typeLabel(subProp)}
+                            </Box>
+                            {subProp.knownValues && (
+                              <Box
+                                sx={{
+                                  fontFamily: fonts.mono,
+                                  fontSize: "10px",
+                                  color: palette.inkFaint,
+                                  mt: "2px",
+                                  wordBreak: "break-word",
+                                }}
+                              >
+                                <strong>{"Known values: "}</strong>
+                                {subProp.knownValues.join(", ")}
+                              </Box>
+                            )}
+                          </Box>
+                        </Box>
+                      ))}
+                    </Box>
+                  );
+                })}
             </Box>
           </Box>
         );

--- a/site/src/data/lexicons.ts
+++ b/site/src/data/lexicons.ts
@@ -1,6 +1,7 @@
 import occurrenceJson from "../../../lexicons/bio/lexicons/temp/v0-1/occurrence.json";
 import identificationJson from "../../../lexicons/bio/lexicons/temp/v0-1/identification.json";
 import mediaJson from "../../../lexicons/bio/lexicons/temp/v0-1/media.json";
+import defsJson from "../../../lexicons/bio/lexicons/temp/v0-1/defs.json";
 
 export interface LexiconDef {
   type: string;
@@ -33,6 +34,7 @@ export interface LexiconProperty {
   maxSize?: number;
   required?: boolean;
   def?: string;
+  refs?: string[];
 }
 
 export interface Lexicon {
@@ -162,12 +164,46 @@ export const MODELS: ModelConfig[] = [
         taxonID: "https://www.gbif.org/species/2880791",
         identificationRemarks:
           "Blue head and wings, white eyebrow, gray-brown back — classic California Scrub-Jay",
+        identifiedBy: {
+          $type: "bio.lexicons.temp.v0-1.defs#agent",
+          agentType: "person",
+          name: "Jane Naturalist",
+          identifier: "https://orcid.org/0000-0002-1825-0097",
+        },
       },
       null,
       2
     ),
   },
 ];
+
+/** All lexicons whose defs can be referenced by `<nsid>#<def>`. */
+const ALL_LEXICONS: Lexicon[] = [
+  occurrenceJson as unknown as Lexicon,
+  mediaJson as unknown as Lexicon,
+  identificationJson as unknown as Lexicon,
+  defsJson as unknown as Lexicon,
+];
+
+/** Registry of every def keyed by its fully-qualified ref `<nsid>#<def>`. */
+const REF_REGISTRY: Record<string, LexiconDef> = {};
+for (const lex of ALL_LEXICONS) {
+  for (const [defName, defBody] of Object.entries(lex.defs)) {
+    REF_REGISTRY[`${lex.id}#${defName}`] = defBody;
+  }
+}
+
+/** Resolve a fully-qualified `<nsid>#<def>` ref to its def body, if known. */
+export function resolveRef(ref: string): LexiconDef | undefined {
+  return REF_REGISTRY[ref];
+}
+
+/** Refs a property points to: union members, or a single `ref`. */
+export function refsOf(prop: LexiconProperty): string[] {
+  if (prop.type === "union") return prop.refs ?? [];
+  if (prop.type === "ref" && prop.ref) return [prop.ref];
+  return [];
+}
 
 /** Lexicon field -> DwC term_localName (when names differ) */
 export const FIELD_TO_DWC: Record<string, string> = {};
@@ -235,6 +271,12 @@ export function getFlatProperties(
 export function typeLabel(prop: LexiconProperty): string {
   const t = prop.type ?? "";
   const fmt = prop.format ?? "";
+  if (t === "union") {
+    const names = (prop.refs ?? []).map((r) =>
+      r.includes("#") ? r.split("#").pop()! : r
+    );
+    return names.length ? `union: ${names.join(" | ")}` : "union";
+  }
   if (t === "ref") {
     const ref = prop.ref ?? "";
     if (ref.startsWith("#")) return ref;


### PR DESCRIPTION
NOT READY FOR REVIEW (YET)

----

## What

Introduces **agent information** to the lexicon, scoped to a single field for now.

- **New `bio.lexicons.temp.v0-1.defs`** — a shared definitions lexicon with an `agent` object def (Darwin Core `dcterms:Agent`):
  - `agentType` — `person | group | organization | machine | software`, per [tdwg/dwc#614](https://github.com/tdwg/dwc/issues/614)
  - `name`, `did` (atproto DID), `identifier` (resolvable external URI, e.g. ORCID)
- **`identification.identifiedBy`** — new field (Darwin Core `dwc:identifiedBy`) typed as an **open `union` with a single variant** (`defs#agent`).

## Why a union with one variant

The field is an inline `agent` object today, but typing it as an open union now means we can later add variants — e.g. a `strongRef` to a standalone agent record — **without a breaking change** to the field's type. Per-instance the value carries a `$type` discriminator.

`agentType: "software"` is the path for model-generated identifications (live-camera-id / AI ID), which a flat `dwc:identifiedBy` string can't express.

## Notes / open questions

- **Singular vs. array.** Modeled as a single agent. DwC `identifiedBy` can name multiple agents — say the word and I'll make it an array.
- **No required fields** on `agent` (permissive during the `temp.` phase).
- **Docs site:** renders generically and won't break, but the union variant won't render its inner fields nicely yet (`site/src/data/lexicons.ts` would need a `union`/cross-file-ref aware renderer + registering `defs.json`). Left as a follow-up.
- **`recordedBy` on `occurrence`** is the obvious sibling reusing `defs#agent`; intentionally out of scope here.

Draft for design review.