### PR TITLE
Model identification taxon as an open union (defs#taxonID variant)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,15 @@ ship in subsequent versions until the prefix is dropped.
 
 ### Added
 - `bio.lexicons.temp.v0-1.defs` — shared definitions lexicon. Introduces a
-  `taxonID` object def: a reference to a taxon by an identifier from an
+  `taxonExternal` object def: a reference to a taxon by an identifier from an
   external taxonomic backbone (GBIF/ITIS/WoRMS), carrying a single `taxonID`
   value (Darwin Core `dwc:taxonID`).
 
 ### Changed
 - `bio.lexicons.temp.v0-1.identification` — replaced the `taxonID` string with
-  a `taxon` field modeled as an open `union` (single variant `defs#taxonID`),
-  following the `app.bsky.embed` external/record pattern. Reserving the union
+  a `taxon` field modeled as an open `union` (single variant
+  `defs#taxonExternal`), following the `app.bsky.embed` external/record
+  pattern. Reserving the union
   shape lets a `strongRef` to a future in-network `Taxon` record be added
   additively rather than as a breaking change. The external identifier now
   lives at `taxon.taxonID` (Darwin Core `dwc:taxonID`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ NSIDs include the version as a segment (e.g. `bio.lexicons.temp.v0-1.occurrence`
 The `temp.` prefix marks the schemas as not yet stable — breaking changes may
 ship in subsequent versions until the prefix is dropped.
 
+## [Unreleased]
+
+### Added
+- `bio.lexicons.temp.v0-1.defs` — shared definitions lexicon. Introduces a
+  `taxonID` object def: a reference to a taxon by an identifier from an
+  external taxonomic backbone (GBIF/ITIS/WoRMS), carrying a single `taxonID`
+  value (Darwin Core `dwc:taxonID`).
+
+### Changed
+- `bio.lexicons.temp.v0-1.identification` — replaced the `taxonID` string with
+  a `taxon` field modeled as an open `union` (single variant `defs#taxonID`),
+  following the `app.bsky.embed` external/record pattern. Reserving the union
+  shape lets a `strongRef` to a future in-network `Taxon` record be added
+  additively rather than as a breaking change. The external identifier now
+  lives at `taxon.taxonID` (Darwin Core `dwc:taxonID`).
+
 ## [0.1] — 2026-04-27
 
 Initial tagged release. Three record types under `bio.lexicons.temp.v0-1.*`.

--- a/lexicons/bio/lexicons/temp/v0-1/defs.json
+++ b/lexicons/bio/lexicons/temp/v0-1/defs.json
@@ -1,0 +1,18 @@
+{
+  "lexicon": 1,
+  "id": "bio.lexicons.temp.v0-1.defs",
+  "defs": {
+    "taxonID": {
+      "type": "object",
+      "description": "A reference to a taxon by an identifier from an external taxonomic backbone (e.g. GBIF, ITIS, WoRMS).",
+      "required": ["taxonID"],
+      "properties": {
+        "taxonID": {
+          "type": "string",
+          "description": "An identifier for the identified taxon in an external taxonomic backbone. May be a globally unique identifier (e.g. a GBIF species URI or a UUID) or an identifier specific to that authority. Maps to Darwin Core dwc:taxonID.",
+          "maxLength": 512
+        }
+      }
+    }
+  }
+}

--- a/lexicons/bio/lexicons/temp/v0-1/defs.json
+++ b/lexicons/bio/lexicons/temp/v0-1/defs.json
@@ -2,7 +2,7 @@
   "lexicon": 1,
   "id": "bio.lexicons.temp.v0-1.defs",
   "defs": {
-    "taxonID": {
+    "taxonExternal": {
       "type": "object",
       "description": "A reference to a taxon by an identifier from an external taxonomic backbone (e.g. GBIF, ITIS, WoRMS).",
       "required": ["taxonID"],

--- a/lexicons/bio/lexicons/temp/v0-1/identification.json
+++ b/lexicons/bio/lexicons/temp/v0-1/identification.json
@@ -32,10 +32,10 @@
             "description": "Taxonomic kingdom for disambiguating homonyms (Darwin Core dwc:kingdom).",
             "maxLength": 64
           },
-          "taxonID": {
-            "type": "string",
-            "format": "uri",
-            "description": "Stable URI for the identified taxon (e.g. a GBIF species URI). Maps to Darwin Core dwc:taxonID."
+          "taxon": {
+            "type": "union",
+            "refs": ["bio.lexicons.temp.v0-1.defs#taxonID"],
+            "description": "A reference to the identified taxon. Open union so more variants can be added later; currently an external identifier (defs#taxonID, Darwin Core dwc:taxonID)."
           },
           "identificationRemarks": {
             "type": "string",

--- a/lexicons/bio/lexicons/temp/v0-1/identification.json
+++ b/lexicons/bio/lexicons/temp/v0-1/identification.json
@@ -34,8 +34,8 @@
           },
           "taxon": {
             "type": "union",
-            "refs": ["bio.lexicons.temp.v0-1.defs#taxonID"],
-            "description": "A reference to the identified taxon. Open union so more variants can be added later; currently an external identifier (defs#taxonID, Darwin Core dwc:taxonID)."
+            "refs": ["bio.lexicons.temp.v0-1.defs#taxonExternal"],
+            "description": "A reference to the identified taxon. Open union so more variants can be added later; currently an external identifier (defs#taxonExternal, Darwin Core dwc:taxonID)."
           },
           "identificationRemarks": {
             "type": "string",

--- a/site/src/components/FieldTable.tsx
+++ b/site/src/components/FieldTable.tsx
@@ -1,6 +1,13 @@
 import { Box } from "@mui/material";
 import type { LexiconProperty } from "../data/lexicons";
-import { typeLabel, FIELD_TO_DWC, ATPROTO_FIELDS } from "../data/lexicons";
+import {
+  typeLabel,
+  FIELD_TO_DWC,
+  ATPROTO_FIELDS,
+  refsOf,
+  resolveRef,
+  getDefProperties,
+} from "../data/lexicons";
 import type { DwcTerm } from "../data/dwcTerms";
 import { palette, fonts } from "../theme";
 
@@ -91,6 +98,95 @@ export default function FieldTable({ fields, dwcTerms }: Props) {
                   {prop.knownValues.join(", ")}
                 </Box>
               )}
+              {refsOf(prop)
+                .map((ref) => ({ ref, def: resolveRef(ref) }))
+                .filter((r) => r.def)
+                .map(({ ref, def }) => {
+                  const refName = ref.includes("#")
+                    ? ref.split("#").pop()!
+                    : ref;
+                  const { properties, required } = getDefProperties(def!);
+                  return (
+                    <Box
+                      key={ref}
+                      sx={{
+                        mt: "8px",
+                        pl: "12px",
+                        borderLeft: `2px solid ${palette.ruleSoft}`,
+                      }}
+                    >
+                      <Box
+                        sx={{
+                          fontFamily: fonts.mono,
+                          fontSize: "10.5px",
+                          color: palette.inkFaint,
+                          mb: "4px",
+                        }}
+                      >
+                        {refName}
+                      </Box>
+                      {Object.entries(properties).map(([subName, subProp]) => (
+                        <Box
+                          key={subName}
+                          sx={{
+                            display: "flex",
+                            flexDirection: { xs: "column", sm: "row" },
+                            gap: { xs: "1px", sm: "10px" },
+                            py: "4px",
+                          }}
+                        >
+                          <Box
+                            sx={{
+                              fontFamily: fonts.mono,
+                              fontSize: "11.5px",
+                              color: palette.forest,
+                              flex: { sm: "0 0 150px" },
+                              overflowWrap: "anywhere",
+                            }}
+                          >
+                            {subName}
+                            {required.has(subName) && (
+                              <Box
+                                component="span"
+                                sx={{ color: palette.warn, ml: "4px" }}
+                              >
+                                *
+                              </Box>
+                            )}
+                          </Box>
+                          <Box sx={{ flex: 1, minWidth: 0, fontSize: "12.5px" }}>
+                            {subProp.description ?? ""}
+                            <Box
+                              sx={{
+                                fontFamily: fonts.mono,
+                                fontSize: "10px",
+                                color: palette.inkFaint,
+                                mt: "2px",
+                                wordBreak: "break-word",
+                              }}
+                            >
+                              {typeLabel(subProp)}
+                            </Box>
+                            {subProp.knownValues && (
+                              <Box
+                                sx={{
+                                  fontFamily: fonts.mono,
+                                  fontSize: "10px",
+                                  color: palette.inkFaint,
+                                  mt: "2px",
+                                  wordBreak: "break-word",
+                                }}
+                              >
+                                <strong>{"Known values: "}</strong>
+                                {subProp.knownValues.join(", ")}
+                              </Box>
+                            )}
+                          </Box>
+                        </Box>
+                      ))}
+                    </Box>
+                  );
+                })}
             </Box>
           </Box>
         );

--- a/site/src/data/lexicons.ts
+++ b/site/src/data/lexicons.ts
@@ -1,6 +1,7 @@
 import occurrenceJson from "../../../lexicons/bio/lexicons/temp/v0-1/occurrence.json";
 import identificationJson from "../../../lexicons/bio/lexicons/temp/v0-1/identification.json";
 import mediaJson from "../../../lexicons/bio/lexicons/temp/v0-1/media.json";
+import defsJson from "../../../lexicons/bio/lexicons/temp/v0-1/defs.json";
 
 export interface LexiconDef {
   type: string;
@@ -33,6 +34,7 @@ export interface LexiconProperty {
   maxSize?: number;
   required?: boolean;
   def?: string;
+  refs?: string[];
 }
 
 export interface Lexicon {
@@ -159,7 +161,10 @@ export const MODELS: ModelConfig[] = [
         },
         scientificName: "Aphelocoma californica (Vigors, 1839)",
         taxonRank: "species",
-        taxonID: "https://www.gbif.org/species/2880791",
+        taxon: {
+          $type: "bio.lexicons.temp.v0-1.defs#taxonID",
+          taxonID: "https://www.gbif.org/species/2880791",
+        },
         identificationRemarks:
           "Blue head and wings, white eyebrow, gray-brown back — classic California Scrub-Jay",
       },
@@ -168,6 +173,34 @@ export const MODELS: ModelConfig[] = [
     ),
   },
 ];
+
+/** All lexicons whose defs can be referenced by `<nsid>#<def>`. */
+const ALL_LEXICONS: Lexicon[] = [
+  occurrenceJson as unknown as Lexicon,
+  mediaJson as unknown as Lexicon,
+  identificationJson as unknown as Lexicon,
+  defsJson as unknown as Lexicon,
+];
+
+/** Registry of every def keyed by its fully-qualified ref `<nsid>#<def>`. */
+const REF_REGISTRY: Record<string, LexiconDef> = {};
+for (const lex of ALL_LEXICONS) {
+  for (const [defName, defBody] of Object.entries(lex.defs)) {
+    REF_REGISTRY[`${lex.id}#${defName}`] = defBody;
+  }
+}
+
+/** Resolve a fully-qualified `<nsid>#<def>` ref to its def body, if known. */
+export function resolveRef(ref: string): LexiconDef | undefined {
+  return REF_REGISTRY[ref];
+}
+
+/** Refs a property points to: union members, or a single `ref`. */
+export function refsOf(prop: LexiconProperty): string[] {
+  if (prop.type === "union") return prop.refs ?? [];
+  if (prop.type === "ref" && prop.ref) return [prop.ref];
+  return [];
+}
 
 /** Lexicon field -> DwC term_localName (when names differ) */
 export const FIELD_TO_DWC: Record<string, string> = {};
@@ -235,6 +268,12 @@ export function getFlatProperties(
 export function typeLabel(prop: LexiconProperty): string {
   const t = prop.type ?? "";
   const fmt = prop.format ?? "";
+  if (t === "union") {
+    const names = (prop.refs ?? []).map((r) =>
+      r.includes("#") ? r.split("#").pop()! : r
+    );
+    return names.length ? `union: ${names.join(" | ")}` : "union";
+  }
   if (t === "ref") {
     const ref = prop.ref ?? "";
     if (ref.startsWith("#")) return ref;

--- a/site/src/data/lexicons.ts
+++ b/site/src/data/lexicons.ts
@@ -162,7 +162,7 @@ export const MODELS: ModelConfig[] = [
         scientificName: "Aphelocoma californica (Vigors, 1839)",
         taxonRank: "species",
         taxon: {
-          $type: "bio.lexicons.temp.v0-1.defs#taxonID",
+          $type: "bio.lexicons.temp.v0-1.defs#taxonExternal",
           taxonID: "https://www.gbif.org/species/2880791",
         },
         identificationRemarks:


### PR DESCRIPTION
Models the taxon reference on `identification` as an open union (#39).

### What
Replaces the `taxonID` URI string with a `taxon` open `union`. The sole current variant is a new `defs#taxonID` object `{ taxonID: string }` (a backbone identifier — URI, UUID, or dataset-local ID, per DwC). Also introduces the `bio.lexicons.temp.v0-1.defs` lexicon and generic union/ref rendering in the docs-site field table.

```json
// before
"taxonID": "https://www.gbif.org/species/2880791"
// after
"taxon": { "$type": "bio.lexicons.temp.v0-1.defs#taxonID", "taxonID": "https://www.gbif.org/species/2880791" }
```

### Why
Lets us add a `strongRef` variant for a future in-network `Taxon` record **additively**, with no breaking change to the field's type.

### Naming convention
Follows the `app.bsky.embed` pattern: the field is the concept (`taxon`), and each union variant is named by *kind* with its payload key mirroring the `$type`. Future shape:

```json
"taxon": { "$type": "bio.lexicons.temp.v0-1.defs#taxonID",      "taxonID": "https://www.gbif.org/species/212" }
"taxon": { "$type": "com.atproto.repo.strongRef", "uri": "at://…/taxon/…", "cid": "bafy…" }
```

The in-network case reuses a bare `com.atproto.repo.strongRef` (already a `$type`-bearing object). The DwC term `dwc:taxonID` lives on the external variant's leaf (`taxon.taxonID`) and flattens to a `taxonID` column on DwC-A export.

Breaking field change, acceptable under the `temp.` prefix.

Refs #39.